### PR TITLE
fix: 修复支付宝 SDK 私钥签名格式

### DIFF
--- a/src/server/alipay.ts
+++ b/src/server/alipay.ts
@@ -22,6 +22,10 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" ? value as Record<string, unknown> : {};
 }
 
+export function prepareAlipaySdkPem(value: string) {
+  return value.trim();
+}
+
 export class OfficialAlipayProvider implements AccountLogProvider {
   constructor(private readonly database: AppDatabase) {}
 
@@ -35,8 +39,8 @@ export class OfficialAlipayProvider implements AccountLogProvider {
 
     const sdk = new AlipaySdk({
       appId,
-      privateKey,
-      alipayPublicKey,
+      privateKey: prepareAlipaySdkPem(privateKey),
+      alipayPublicKey: prepareAlipaySdkPem(alipayPublicKey),
       signType: "RSA2",
       keyType: "PKCS8",
       endpoint: getSetting(this.database, "alipay_endpoint", "https://openapi.alipay.com"),

--- a/tests/alipay-sdk.test.ts
+++ b/tests/alipay-sdk.test.ts
@@ -1,0 +1,24 @@
+import { createPrivateKey, createPublicKey, createSign } from "node:crypto";
+import { describe, expect, it } from "bun:test";
+import { AlipaySdk } from "alipay-sdk";
+import { prepareAlipaySdkPem } from "../src/server/alipay";
+import { generateRsaKeyPair } from "../src/server/security";
+
+describe("Alipay SDK key compatibility", () => {
+  it("removes trailing PEM whitespace before the SDK formats generated keys", () => {
+    const pair = generateRsaKeyPair();
+    expect(pair.privateKey.endsWith("\n")).toBe(true);
+
+    const sdk = new AlipaySdk({
+      appId: "2026000000000000",
+      privateKey: prepareAlipaySdkPem(pair.privateKey),
+      alipayPublicKey: prepareAlipaySdkPem(pair.publicKey),
+      keyType: "PKCS8",
+      signType: "RSA2",
+    });
+
+    expect(() => createPrivateKey(sdk.config.privateKey)).not.toThrow();
+    expect(() => createPublicKey(sdk.config.alipayPublicKey!)).not.toThrow();
+    expect(() => createSign("RSA-SHA256").update("probe").sign(sdk.config.privateKey)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## 修正

- 在传给 `alipay-sdk` 前去掉 PEM 首尾空白
- 同时处理应用私钥和支付宝公钥
- 兼容数据库中已经保存的密钥，无需重新生成

## 根因

`alipay-sdk@4.14.0` 格式化带末尾换行的 PEM 时，会把结束标记误拼进 Base64 正文，随后 OpenSSL 报 `BAD_BASE64_DECODE`。

## 验证

- 最小复现确认旧路径稳定触发 `BAD_BASE64_DECODE`，修正后 SDK 可正常签名
- 新增同版本 SDK 回归测试
- `bun run check`：类型检查、23 个测试和生产构建通过